### PR TITLE
Use template variables in title parameter

### DIFF
--- a/core/components/siteatoz/elements/snippets/siteatoz.snippet.php
+++ b/core/components/siteatoz/elements/snippets/siteatoz.snippet.php
@@ -129,14 +129,28 @@ foreach ($alphabet as $k=>$v) {
     if ($useJS) {
         $output .= "\n\n" . '<div style="display:none;" class="az-section" id="a' . $v . '">' . "\n";
     }
-    if ($combineNumbers && ($v == '[0-9]') ) {
-        $local_where = array(
-            $title . ':REGEXP' => '^[0-9]',
-        );
+    if (substr($title, 0, 2 ) !== "tv") {
+        if ($combineNumbers && ($v == '[0-9]') ) {
+            $local_where = array(
+                $title . ':REGEXP' => '^[0-9]',
+            );
+        } else {
+            $local_where = array(
+                $title . ':LIKE' => $v . '%',
+            );
+        }
+        $sp['where'] = $modx->toJSON($local_where);
     } else {
-        $local_where = array(
-            $title . ':LIKE' => $v . '%',
-        );
+        $tvtitle = substr($title, 2);
+        if ($combineNumbers && ($v == '[0-9]') ) {
+            $sp['tvFilters'] = array();
+            for ($i = 0; $i <= 9; $i++) {
+                $sp['tvFilters'][] = $tvtitle . '==' . (string) $i . '%';
+            }
+            $sp['tvFilters'] = implode('||', $sp['tvFilters']);
+        } else {
+            $sp['tvFilters'] = $tvtitle . '==' . $v . '%';
+        }
     }
     /* ToDo: Some day this may work */
     /*if ($whereProperty !== false) {
@@ -144,7 +158,6 @@ foreach ($alphabet as $k=>$v) {
         $local_where = array_merge($local_where,$w);
         unset($w);
     }*/
-    $sp['where'] = $modx->toJSON($local_where);
 
     $ret = $modx->runSnippet('getResources',$sp);
     if (empty($ret)) {


### PR DESCRIPTION
TVs have to be prefixed with 'tv' to use them in the title parameter.