### PR TITLE
add hideUnsearchable option

### DIFF
--- a/core/components/siteatoz/elements/snippets/siteatoz.snippet.php
+++ b/core/components/siteatoz/elements/snippets/siteatoz.snippet.php
@@ -45,6 +45,7 @@
  * @property noData - (string) String to show if search comes up empty.
  * @property cssFile - (string) Path to css file.
  * @property useJS - (boolean) - Use JS to hide entries until link is clicked.
+ * @property hideUnsearchable - (boolean) - Only show items which have their "Searchable" box checked; default '0'.
  *
  * All other parameters are those of getResources. They should all work as they do for getResources with two exceptions:
  * @property resources can be used to exclude documents (e.g., &resources=`-2,24`), but not to include them .
@@ -89,6 +90,7 @@ $useNumbers = $modx->getOption('useNumbers', $sp, false, true);
 $combineNumbers = $modx->getOption('combineNumbers', $sp, false, true);
 $useAlphabet = $modx->getOption('useAlphabet', $sp, true);
 $useJS = $modx->getOption('useJS', $sp, false, true);
+$hideUnsearchable = $modx->getOption('hideUnsearchable', $sp, '0', true);
 
 if ($combineNumbers) {
     $n = array('[0-9]');
@@ -137,6 +139,10 @@ foreach ($alphabet as $k => $v) {
         $local_where = array(
             $title . ':LIKE' => $v . '%',
         );
+    }
+
+    if($hideUnsearchable == '1') {
+        $local_where['searchable'] = 1;
     }
 
     $sp['where'] = $modx->toJSON($local_where);


### PR DESCRIPTION
This pull request adds an option to hide documents that should not show up in the search index. The thinking is that, if it shouldn't be found via search, it probably shouldn't be found in the A to Z listing either. Since the `where` property for getResources can't be used, adding an option seemed to be the best way to do it.